### PR TITLE
Add simple auth pages

### DIFF
--- a/flask_react/app/(auth)/sign-in/page.tsx
+++ b/flask_react/app/(auth)/sign-in/page.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useForm } from "react-hook-form"
+import { Button, Input, Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui"
+import { signIn } from "@/lib/auth-client"
+
+interface SignInData {
+  email: string
+  password: string
+}
+
+export default function SignInPage() {
+  const router = useRouter()
+  const form = useForm<SignInData>({
+    defaultValues: { email: "", password: "" },
+  })
+
+  const onSubmit = async (data: SignInData) => {
+    const res = await signIn.email({ email: data.email, password: data.password })
+    if (res?.data?.user) {
+      router.push("/dashboard")
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 w-full max-w-sm">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input type="email" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Password</FormLabel>
+                <FormControl>
+                  <Input type="password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" className="w-full">Sign In</Button>
+        </form>
+      </Form>
+    </div>
+  )
+}

--- a/flask_react/app/(auth)/sign-up/page.tsx
+++ b/flask_react/app/(auth)/sign-up/page.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useForm } from "react-hook-form"
+import { Button, Input, Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui"
+import { signUp } from "@/lib/auth-client"
+
+interface SignUpData {
+  name: string
+  email: string
+  password: string
+}
+
+export default function SignUpPage() {
+  const router = useRouter()
+  const form = useForm<SignUpData>({
+    defaultValues: { name: "", email: "", password: "" },
+  })
+
+  const onSubmit = async (data: SignUpData) => {
+    const res = await signUp.email({ email: data.email, password: data.password, name: data.name })
+    if (res?.data?.user) {
+      router.push("/dashboard")
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 w-full max-w-sm">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input type="email" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Password</FormLabel>
+                <FormControl>
+                  <Input type="password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" className="w-full">Sign Up</Button>
+        </form>
+      </Form>
+    </div>
+  )
+}

--- a/flask_react/lib/auth-client.ts
+++ b/flask_react/lib/auth-client.ts
@@ -2,4 +2,4 @@ import { createAuthClient } from 'better-auth/react'
 
 const client = createAuthClient()
 
-export const { signIn, signOut, useSession } = client
+export const { signIn, signUp, signOut, useSession } = client


### PR DESCRIPTION
## Summary
- create sign-in and sign-up pages under `(auth)` route group
- hook up pages to the Better Auth client and export `signUp`

## Testing
- `npm run lint`
- `pytest -q` *(fails: ModuleNotFoundError for `llama_cloud`)*

------
https://chatgpt.com/codex/tasks/task_e_687c2899ae2c83278c0d3e19ac477147