### PR TITLE
Add dashboard pages with session checks

### DIFF
--- a/flask_react/app/dashboard/layout.tsx
+++ b/flask_react/app/dashboard/layout.tsx
@@ -1,0 +1,14 @@
+import { auth } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+
+export default async function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const { data: session } = await auth.api.getSession()
+  if (!session) {
+    redirect('/sign-in')
+  }
+  return <>{children}</>
+}

--- a/flask_react/app/dashboard/loading.tsx
+++ b/flask_react/app/dashboard/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return null
+}

--- a/flask_react/app/dashboard/page.tsx
+++ b/flask_react/app/dashboard/page.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { useState } from 'react'
+import { Sidebar, Header, Documents, Marketplace } from '@/components/dashboard'
+import { useSession } from '@/lib/auth-client'
+
+export default function DashboardPage() {
+  const { data: session } = useSession()
+  const [view, setView] = useState<'documents' | 'marketplace'>('documents')
+
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <div className="flex flex-col flex-1">
+        <Header />
+        {session && (
+          <p className="px-4 py-2 text-sm text-gray-600">Welcome back, {session.user?.name}!</p>
+        )}
+        <nav className="border-b px-4 pt-2">
+          <button
+            className={`mr-4 pb-2 border-b-2 ${view === 'documents' ? 'border-blue-500' : 'border-transparent'}`}
+            onClick={() => setView('documents')}
+          >
+            Documents
+          </button>
+          <button
+            className={`pb-2 border-b-2 ${view === 'marketplace' ? 'border-blue-500' : 'border-transparent'}`}
+            onClick={() => setView('marketplace')}
+          >
+            Marketplace
+          </button>
+        </nav>
+        <main className="flex-1 overflow-y-auto">
+          {view === 'documents' ? <Documents /> : <Marketplace />}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/flask_react/components/dashboard/Documents.tsx
+++ b/flask_react/components/dashboard/Documents.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { useSession } from "@/lib/auth-client"
+
+export function Documents() {
+  const { data: session } = useSession()
+
+  return (
+    <div className="p-4">
+      <h2 className="text-lg font-semibold mb-2">Documents</h2>
+      <p className="text-sm text-gray-600">Showing documents for {session?.user?.name ?? 'you'}.</p>
+      <div className="mt-4 rounded border border-dashed p-8 text-center text-gray-500">
+        No documents to display.
+      </div>
+    </div>
+  )
+}

--- a/flask_react/components/dashboard/Header.tsx
+++ b/flask_react/components/dashboard/Header.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { signOut, useSession } from "@/lib/auth-client"
+
+export function Header() {
+  const { data: session } = useSession()
+
+  return (
+    <header className="flex items-center justify-between border-b p-4">
+      <h1 className="text-lg font-semibold">Dashboard</h1>
+      <div className="flex items-center gap-4">
+        <span className="text-sm text-gray-600">{session?.user?.name}</span>
+        <button
+          onClick={() => signOut({})}
+          className="text-sm text-blue-600 hover:underline"
+        >
+          Sign Out
+        </button>
+      </div>
+    </header>
+  )
+}

--- a/flask_react/components/dashboard/Marketplace.tsx
+++ b/flask_react/components/dashboard/Marketplace.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { useSession } from "@/lib/auth-client"
+
+export function Marketplace() {
+  const { data: session } = useSession()
+
+  return (
+    <div className="p-4">
+      <h2 className="text-lg font-semibold mb-2">Marketplace</h2>
+      <p className="text-sm text-gray-600">Welcome {session?.user?.name ?? 'user'}.</p>
+      <div className="mt-4 rounded border border-dashed p-8 text-center text-gray-500">
+        Marketplace coming soon.
+      </div>
+    </div>
+  )
+}

--- a/flask_react/components/dashboard/Sidebar.tsx
+++ b/flask_react/components/dashboard/Sidebar.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+
+export function Sidebar() {
+  const pathname = usePathname()
+
+  const links = [
+    { href: "/dashboard", label: "Documents" },
+    { href: "/dashboard/marketplace", label: "Marketplace" },
+  ]
+
+  return (
+    <aside className="w-48 border-r bg-gray-50 p-4 space-y-2">
+      {links.map(({ href, label }) => (
+        <Link
+          key={href}
+          href={href}
+          className={`block px-2 py-1 rounded hover:bg-gray-100 ${
+            pathname === href ? "font-semibold" : ""
+          }`}
+        >
+          {label}
+        </Link>
+      ))}
+    </aside>
+  )
+}

--- a/flask_react/components/dashboard/index.ts
+++ b/flask_react/components/dashboard/index.ts
@@ -1,0 +1,4 @@
+export * from './Sidebar'
+export * from './Header'
+export * from './Documents'
+export * from './Marketplace'


### PR DESCRIPTION
## Summary
- add dashboard layout and loading files
- create dashboard page using `useSession`
- break dashboard into Sidebar, Header, Documents and Marketplace components

## Testing
- `npm run lint`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687c2c3823208327836bd9058daf8ab7