### PR TITLE
Add middleware for protected dashboard

### DIFF
--- a/flask_react/middleware.ts
+++ b/flask_react/middleware.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getSessionCookie } from 'better-auth/cookies'
+
+export function middleware(request: NextRequest) {
+  const sessionToken = getSessionCookie(request)
+  if (!sessionToken) {
+    return NextResponse.redirect(new URL('/sign-in', request.url))
+  }
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*'],
+}


### PR DESCRIPTION
## Summary
- implement Next.js middleware to check for session cookies
- redirect to sign-in if missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'llama_cloud')*

------
https://chatgpt.com/codex/tasks/task_e_687c3783317c8327b6de0bd0727221d4