### PR TITLE
Integrate Better Auth with Neon Postgres

### DIFF
--- a/flask_react/app/api/auth/[...all]/route.ts
+++ b/flask_react/app/api/auth/[...all]/route.ts
@@ -1,0 +1,4 @@
+import { auth } from "@/lib/auth";
+import { toNextJsHandler } from "better-auth/next-js";
+
+export const { GET, POST } = toNextJsHandler(auth.handler);

--- a/flask_react/app/layout.tsx
+++ b/flask_react/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { AutumnProvider } from "better-auth/react";
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -14,7 +15,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <AutumnProvider betterAuthUrl={process.env.NEXT_PUBLIC_BETTER_AUTH_URL}>
+          {children}
+        </AutumnProvider>
+      </body>
     </html>
   )
 }

--- a/flask_react/lib/auth-client.ts
+++ b/flask_react/lib/auth-client.ts
@@ -1,0 +1,3 @@
+import { createAuthClient } from "better-auth/react";
+
+export const authClient = createAuthClient({});

--- a/flask_react/lib/auth.ts
+++ b/flask_react/lib/auth.ts
@@ -1,0 +1,10 @@
+import { betterAuth } from "better-auth";
+import { Pool } from "pg";
+import { nextCookies } from "better-auth/next-js";
+
+export const auth = betterAuth({
+  baseURL: process.env.BETTER_AUTH_URL,
+  database: new Pool({ connectionString: process.env.DATABASE_URL }),
+  emailAndPassword: { enabled: true },
+  plugins: [nextCookies()],
+});


### PR DESCRIPTION
## Summary
- add auth helper using Better Auth
- mount Better Auth API route
- add client helper for React
- wrap app with `AutumnProvider`
- attempt `npx @better-auth/cli migrate`

## Testing
- `pnpm lint`
- `npx --yes @better-auth/cli migrate` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_687ef42392648327925dc4d77787bf8b